### PR TITLE
Update CI To Build Image

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v2
     - name: run linter
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./ v1.31.0
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./ v1.46.2
         make lint PATH=$PATH:`pwd`
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
     - main
-    - dockerfile
     tags:
     - v*
 jobs:
@@ -36,7 +35,7 @@ jobs:
         make build VERSION="${version}"
         echo "::set-output name=version::${version}"
   image:
-    if: ${{ startsWith(github.ref, 'refs/tags') || github.ref == 'refs/heads/dockerfile' }}
+    if: ${{ startsWith(github.ref, 'refs/tags') }}
     needs:
     - lint
     - build
@@ -44,7 +43,12 @@ jobs:
     steps:
     - name: checkout code
       uses: actions/checkout@v2
-    - run: make image VERSION=${{ needs.build.outputs.version }}
+    - uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - run: make image VERSION=${{ needs.build.outputs.version }} IMAGE_PUSH="true"
   release:
     if: ${{ startsWith(github.ref, 'refs/tags') }}
     needs:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -2,11 +2,12 @@ on:
   push:
     branches:
     - main
+    - dockerfile
     tags:
     - v*
 jobs:
   lint:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: checkout code
       uses: actions/checkout@v2
@@ -15,7 +16,7 @@ jobs:
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./ v1.31.0
         make lint PATH=$PATH:`pwd`
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.build.outputs.version }}
     steps:
@@ -34,16 +35,21 @@ jobs:
         version=$(echo "${{ github.ref }}" | awk -F'/' '{print $3}')
         make build VERSION="${version}"
         echo "::set-output name=version::${version}"
-  release:
-    if: ${{ startsWith(github.ref, 'refs/tags') }}
+  image:
+    if: ${{ startsWith(github.ref, 'refs/tags') || github.ref == 'refs/heads/dockerfile' }}
     needs:
     - lint
     - build
-    runs-on: ubuntu-18.04
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+    runs-on: ubuntu-22.04
+    steps:
+    - name: checkout code
+      uses: actions/checkout@v2
+    - run: make image VERSION=${{ needs.build.outputs.version }}
+  release:
+    if: ${{ startsWith(github.ref, 'refs/tags') }}
+    needs:
+    - image
+    runs-on: ubuntu-22.04
     steps:
     - name: install Go
       uses: actions/setup-go@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 FROM debian:bookworm-20220622
 ARG KUBECTL_VERSION=v1.24.0 \
     KREW_VERSION=v0.4.3
-ENV KREW_ROOT=/opt/.krew
 RUN apt update -y && \
   apt install -y curl git && \
   curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
   curl -LO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/krew-linux_amd64.tar.gz" && \
   install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
   tar -C /usr/local/bin -xvf krew-linux_amd64.tar.gz && \
-  /usr/local/bin/krew-linux_amd64 install krew && \
-  rm krew-linux_amd64.tar.gz
-ENV PATH="${KREW_ROOT}/bin:${PATH}"
+  rm krew-linux_amd64.tar.gz && \
+  useradd -rm -d /home/promdump -s /bin/bash promdump
+USER promdump
+WORKDIR /home/promdump
+RUN  /usr/local/bin/krew-linux_amd64 install krew
+ENV PATH="/home/promdump/.krew/bin:${PATH}"
 RUN kubectl krew update && \
   kubectl krew install promdump
 CMD ["kubectl", "promdump", "-h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:bookworm-20220622
+ARG KUBECTL_VERSION=v1.24.0 \
+    KREW_VERSION=v0.4.3
+ENV KREW_ROOT=/opt/.krew
+RUN apt update -y && \
+  apt install -y curl git && \
+  curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+  curl -LO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/krew-linux_amd64.tar.gz" && \
+  install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+  tar -C /usr/local/bin -xvf krew-linux_amd64.tar.gz && \
+  /usr/local/bin/krew-linux_amd64 install krew && \
+  rm krew-linux_amd64.tar.gz
+ENV PATH="${KREW_ROOT}/bin:${PATH}"
+RUN kubectl krew update && \
+  kubectl krew install promdump
+CMD ["kubectl", "promdump", "-h"]

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ TARGET_BIN_DIR = $(TARGET_DIR)/bin
 TARGET_RELEASE_DIR = $(TARGET_DIR)/releases/$(VERSION)
 TARGET_PLUGINS_DIR = $(TARGET_RELEASE_DIR)/plugins
 
+IMAGE_REPO ?= ghcr.io/ihcsim/krew-promdump
+
 all: test lint build
 
 build: prebuild core cli
@@ -73,6 +75,9 @@ plugin:
 	tar -C "$(TARGET_PLUGINS_DIR)" -czvf "$(TARGET_PLUGINS_DIR)/kubectl-promdump-$(BUILD_OS)-$(BUILD_ARCH)-$(VERSION).tar.gz" kubectl-promdump$${extension} LICENSE && \
 	rm "$(TARGET_PLUGINS_DIR)/kubectl-promdump$${extension}" && \
 	shasum -a256 $(TARGET_PLUGINS_DIR)/kubectl-promdump-$(BUILD_OS)-$(BUILD_ARCH)-$(VERSION).tar.gz | awk '{print $$1}' > $(TARGET_PLUGINS_DIR)/kubectl-promdump-$(BUILD_OS)-$(BUILD_ARCH)-$(VERSION).tar.gz.sha256
+
+image:
+	docker build --rm -t ${IMAGE_REPO}:${VERSION} .
 
 .PHONY: hack/prometheus-repos
 hack/prometheus-repos:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,10 @@ plugin:
 	shasum -a256 $(TARGET_PLUGINS_DIR)/kubectl-promdump-$(BUILD_OS)-$(BUILD_ARCH)-$(VERSION).tar.gz | awk '{print $$1}' > $(TARGET_PLUGINS_DIR)/kubectl-promdump-$(BUILD_OS)-$(BUILD_ARCH)-$(VERSION).tar.gz.sha256
 
 image:
-	docker build --rm -t ${IMAGE_REPO}:${VERSION} .
+	docker build --rm -t $(IMAGE_REPO):$(VERSION) .
+	if [ $${IMAGE_PUSH} ]; then \
+		docker push $(IMAGE_REPO):$(VERSION) ;\
+	fi
 
 .PHONY: hack/prometheus-repos
 hack/prometheus-repos:


### PR DESCRIPTION
This PR:

1. Added a  new Dockerfile
2. Update CI jobs to run on Ubuntu 22.04
3. Upgrade golangci-lint to latest version
4. Update CI to push Docker image to ghcr.io